### PR TITLE
Fixes

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/tomosaic/merge/merge.py
+++ b/tomosaic/merge/merge.py
@@ -218,8 +218,8 @@ def img_merge_alpha(img1, img2, shift, alpha=0.4):
     ndarray
     """
     print('Alpha Blend = ' + str(alpha))
-    newimg1 = morph.arrange_image(img1, img2, shift, order=1)
-    newimg2 = morph.arrange_image(img1, img2, shift, order=2)
+    newimg1, _ = morph.arrange_image(img1, img2, shift, order=1)
+    newimg2, _ = morph.arrange_image(img1, img2, shift, order=2)
     final_img = alpha * newimg1 + (1 - alpha) * newimg2
     return final_img
 
@@ -228,7 +228,7 @@ def img_merge_overlay(img1, img2, shift):
     """
     Simple overlay of two images. Equivalent to alpha blending with alpha = 1.
     """
-    newimg = morph.arrange_image(img1, img2, shift, order=1)
+    newimg, _ = morph.arrange_image(img1, img2, shift, order=1)
     return newimg
 
 
@@ -248,8 +248,8 @@ def img_merge_max(img1, img2, shift):
         Output array.
     """
     print('Max Blend')
-    newimg1 = morph.arrange_image(img1, img2, shift, order=1)
-    newimg2 = morph.arrange_image(img1, img2, shift, order=2)
+    newimg1, _ = morph.arrange_image(img1, img2, shift, order=1)
+    newimg2, _ = morph.arrange_image(img1, img2, shift, order=2)
     buff = np.dstack((newimg1, newimg2))
     final_img = buff.max(2)
 
@@ -271,8 +271,8 @@ def img_merge_min(img1, img2, shift):
     ndarray
         Output array.
     """
-    newimg1 = morph.arrange_image(img1, img2, shift, order=1)
-    newimg2 = morph.arrange_image(img1, img2, shift, order=2)
+    newimg1, _ = morph.arrange_image(img1, img2, shift, order=1)
+    newimg2, _ = morph.arrange_image(img1, img2, shift, order=2)
     buff = np.dstack((newimg1, newimg2))
     final_img = buff.min(2)
 
@@ -281,7 +281,7 @@ def img_merge_min(img1, img2, shift):
 
 # Modified for subpixel fourier shift.
 def img_merge_poisson(img1, img2, shift):
-    newimg = morph.arrange_image(img1, img2, shift)
+    newimg, img2 = morph.arrange_image(img1, img2, shift)
     if abs(shift[0]) < 10 and abs(shift[1]) < 10:
         return newimg
     # Get corner positions for img2 INCLUDING boundary.
@@ -567,7 +567,7 @@ def _collapse(lapl_pyr, blur):
 def img_merge_pwd(img1, img2, shift, margin=100, chunk_size=10000):
     t00 = time.time()
     t0 = time.time()
-    newimg = morph.arrange_image(img1, img2, shift, order=2)
+    newimg, _ = morph.arrange_image(img1, img2, shift, order=2)
     print('Starting PWD blend...')
     if abs(shift[0]) < margin and abs(shift[1]) < margin:
         return newimg

--- a/tomosaic/merge/merge.py
+++ b/tomosaic/merge/merge.py
@@ -447,10 +447,11 @@ def _circ_neighbor(mat):
 # Codes are adapted from Computer Vision Lab, Image blending using pyramid, https://compvisionlab.wordpress.com/2013/
 # 05/13/image-blending-using-pyramid/.
 def img_merge_pyramid(img1, img2, shift, margin=100, blur=0.4, depth=4):
+
     t00 = time.time()
     t0 = time.time()
     # print(    'Starting pyramid blend...')
-    newimg = morph.arrange_image(img1, img2, shift)
+    newimg, img2 = morph.arrange_image(img1, img2, shift)
     if abs(shift[0]) < margin and abs(shift[1]) < margin:
         return newimg
     # print('    Blend: Image aligned and built in', str(time.time() - t0))

--- a/tomosaic/recon/recon.py
+++ b/tomosaic/recon/recon.py
@@ -134,28 +134,28 @@ def recon_hdf5(src_fanme, dest_folder, sino_range, sino_step, shift_grid, center
             print('Block {:d} finished in {:.2f} s.'.format(iblock, time.time()-t0))
     else:
         # divide chunks
-        grid_bins = np.append(np.ceil(shift_grid[:, 0, 0]), sino_ls[-1]-1)
+        grid_bins = np.append(np.ceil(shift_grid[:, 0, 0]), full_shape[1])
         chunks = []
         center_ls = []
         istart = 0
         counter = 0
-        irow = np.searchsorted(grid_bins, sino_ls[0])-1
+        # irow should be 0 for slice 0
+        irow = np.searchsorted(grid_bins, sino_ls[0], side='right')-1
 
         for i in range(sino_ls.size):
             counter += 1
             print(sino_ls[i], grid_bins[irow], i)
-            if counter >= chunk_size or sino_ls[i] >= grid_bins[irow]:
+            sino_next = i+1 if i != sino_ls.size-1 else i
+            if counter >= chunk_size or sino_ls[sino_next] >= grid_bins[irow+1] or sino_next == i:
                 iend = i+1
                 chunks.append((istart, iend))
                 print(i, chunks)
                 istart = iend
-                center_ls.append(center_vec[irow-1])
-                if sino_ls[i] >= grid_bins[irow]:
+                center_ls.append(center_vec[irow])
+                if sino_ls[sino_next] >= grid_bins[irow+1]:
                     irow += 1
                 counter = 0
-        if sino_ls[i] < grid_bins[irow-1]:
-            chunks.append((istart, sino_ls.size))
-            center_ls.append(center_vec[irow-1])
+
         # reconstruct chunks
         print(chunks)
         print(sino_ls)

--- a/tomosaic/register/morph.py
+++ b/tomosaic/register/morph.py
@@ -146,9 +146,10 @@ def realign_image(arr, shift, angle=0):
     ndarray
         Output array.
     """
+    # if both shifts are integers, do circular shift; otherwise perform Fourier shift.
     if np.count_nonzero(np.abs(np.array(shift) - np.round(shift)) < 0.01) == 2:
         temp = np.roll(arr, int(shift[0]), axis=0)
-        temp = np.roll(arr, int(shift[1]), axis=1)
+        temp = np.roll(temp, int(shift[1]), axis=1)
         temp = temp.astype('float32')
     else:
         temp = fourier_shift(np.fft.fftn(arr), shift)

--- a/tomosaic/register/morph.py
+++ b/tomosaic/register/morph.py
@@ -58,6 +58,7 @@ from scipy.ndimage import fourier_shift
 import numpy as np
 import operator
 import dxchange
+import gc
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,7 @@ __all__ = ['realign_image',
            'vig_image']
 
 
-def arrange_image(img1, img2, shift, order=1):
+def arrange_image(img1, img2, shift, order=1, trim=True):
     """
     Place properly aligned image in buff
 
@@ -87,6 +88,9 @@ def arrange_image(img1, img2, shift, order=1):
     order : int
         Order that images are arranged. If order is 1, img1 is written first and img2 is placed on the top. If order is
         2, img2 is written first and img1 is placed on the top.
+    trim : bool
+        In the case that shifts involve negative or float numbers where Fourier shift is needed, remove the circular
+        shift stripe.
 
     Returns
     -------
@@ -94,7 +98,13 @@ def arrange_image(img1, img2, shift, order=1):
         Output array.
     """
     rough_shift = get_roughshift(shift)
-    img2 = realign_image(img2, shift - rough_shift.astype('float'))
+    adj_shift = shift - rough_shift.astype('float')
+    img2 = realign_image(img2, adj_shift)
+    if trim:
+        temp = np.zeros(img2.shape-np.ceil(np.abs(adj_shift)))
+        temp[:, :] = img2[:temp.shape[0], :temp.shape[1]]
+        img2 = np.copy(temp)
+        temp = 0
     new_shape = map(int, map(max, map(operator.add, img2.shape, rough_shift), img1.shape))
     newimg = np.empty(new_shape)
     newimg[:, :] = np.NaN
@@ -109,7 +119,11 @@ def arrange_image(img1, img2, shift, order=1):
         newimg[0:img1.shape[0], 0:img1.shape[1]][notnan] = img1[notnan]
     else:
         print('Warning: images are not arranged due to misspecified order.')
-    return newimg
+    gc.collect()
+    if trim:
+        return newimg, img2
+    else:
+        return newimg
 
 
 def realign_image(arr, shift, angle=0):
@@ -170,6 +184,7 @@ def realign_block(arr, shift_vector, angle_vector=None, axis=0):
 
 
 def get_roughshift(shift):
+
     rough_shift = np.ceil(shift)
     rough_shift[rough_shift < 0] = 0
     return rough_shift

--- a/tomosaic/util/util.py
+++ b/tomosaic/util/util.py
@@ -169,7 +169,7 @@ def build_panorama(src_folder, file_grid, shift_grid, frame=0, method='max', met
             prj, flt, drk = dxchange.read_aps_32id(temp_grid[0, 0], proj=(frame, frame + 1))
             prj = tomopy.normalize(prj, flt, drk)
             prj = preprecess(prj, blur=blur)
-            row_buff = arrange_image(row_buff, np.squeeze(prj), temp_shift[0, 0, :], order=1)
+            row_buff, _ = arrange_image(row_buff, np.squeeze(prj), temp_shift[0, 0, :], order=1)
             for x in range(1, temp_grid.shape[1]):
                 value = temp_grid[0, x]
                 if (value != None and frame < g_shapes(value)[0]):

--- a/tomosaic/util/util.py
+++ b/tomosaic/util/util.py
@@ -139,10 +139,12 @@ def save_partial_raw(file_grid, save_folder, prefix):
 g_shapes = lambda fname: h5py.File(fname, "r")['exchange/data'].shape
 
 
-def build_panorama(file_grid, shift_grid, frame=0, method='max', method2=None, blend_options={}, blend_options2={},
+def build_panorama(src_folder, file_grid, shift_grid, frame=0, method='max', method2=None, blend_options={}, blend_options2={},
                    blur=None, color_correction=False):
 
     t00 = time.time()
+    root = os.getcwd()
+    os.chdir(src_folder)
     cam_size = g_shapes(file_grid[0, 0])
     cam_size = cam_size[1:3]
     img_size = shift_grid[-1, -1] + cam_size
@@ -182,6 +184,7 @@ def build_panorama(file_grid, shift_grid, frame=0, method='max', method2=None, b
             buff = blend(buff, row_buff, [offset, 0], method=method2, color_correction=False, **blend_options2)
             print('Rank: {:d}; Frame: {:d}; Row: {:d}; Row stitched in {:.2f} s.'.format(rank, frame, y, time.time()-t0))
     print('Rank: {:d}; Frame: {:d}; Panorama built in {:.2f} s.'.format(rank, frame, time.time()-t00))
+    os.chdir(root)
     return buff
 
 
@@ -615,7 +618,7 @@ def total_fusion(src_folder, dest_folder, dest_fname, file_grid, shift_grid, ble
         pano = np.zeros((full_height, full_width), dtype=dtype)
         # save_stdout = sys.stdout
         # sys.stdout = open('log', 'w')
-        temp = build_panorama(file_grid, shift_grid, frame=frame, method=blend_method, method2=blend_method2,
+        temp = build_panorama(src_folder, file_grid, shift_grid, frame=frame, method=blend_method, method2=blend_method2,
                               blend_options=blend_options, blend_options2=blend_options2, blur=blur, color_correction=color_correction)
         temp[np.isnan(temp)] = 0
         # sys.stdout = save_stdout


### PR DESCRIPTION
- Fixed a bug in `recon_hdf5` chunking.
- In the cases where the shift vector involves negative or float numbers and circular rolling or Fourier shift is used, the shifted-over part on the right or bottom sides of the image (`img2`) will be removed, and `img2` will shrink to the new size. This should prevent the occurrence of striking sharp lines previously seen in stitching and blending. 