### PR TITLE
Fix recon_block

### DIFF
--- a/tomosaic/merge/merge.py
+++ b/tomosaic/merge/merge.py
@@ -446,7 +446,7 @@ def _circ_neighbor(mat):
 # Pyramid blend.
 # Codes are adapted from Computer Vision Lab, Image blending using pyramid, https://compvisionlab.wordpress.com/2013/
 # 05/13/image-blending-using-pyramid/.
-def img_merge_pyramid(img1, img2, shift, margin=100, blur=0.4, depth=4):
+def img_merge_pyramid(img1, img2, shift, margin=100, blur=0.4, depth=5):
 
     t00 = time.time()
     t0 = time.time()

--- a/tomosaic/recon/recon.py
+++ b/tomosaic/recon/recon.py
@@ -279,7 +279,7 @@ def recon_block(grid, shift_grid, src_folder, dest_folder, dest_fname, slice_ran
         rec = recon_slice(row_sino, center_pos, sinogram_order=sinogram_order, algorithm=algorithm,
                           init_recon=init_recon, ncore=ncore, nchunk=nchunk, **kwargs)
         print('Center:            {:d}'.format(center_pos))
-        # rec = tomopy.remove_ring(rec)
+        rec = tomopy.remove_ring(rec)
         rec = tomopy.remove_outlier(rec, tolerance)
         rec = tomopy.circ_mask(rec, axis=0, ratio=0.9)
         rec = np.squeeze(rec)
@@ -360,9 +360,10 @@ def recon_slice(row_sino, center_pos, sinogram_order=False, algorithm=None,
         init_recon=None, ncore=None, nchunk=None, **kwargs):
     t = time.time()
     ang = tomopy.angles(row_sino.shape[0])
+    print(row_sino.shape)
     row_sino = row_sino.astype('float32')
     # row_sino = tomopy.remove_stripe_ti(row_sino)
-    row_sino = tomopy.normalize_bg(row_sino)
+    # row_sino = tomopy.normalize_bg(row_sino) # WARNING: normalize_bg can unpredicatably give bad results for some slices
     rec = tomopy.recon(row_sino, ang, center=center_pos, sinogram_order=sinogram_order, algorithm=algorithm,
         init_recon=init_recon, ncore=ncore, nchunk=nchunk, **kwargs)
 


### PR DESCRIPTION
- The strange behavior of `recon_block` which generates smeared reconstructions for some slices was found to be due to `tomopy.normalize_bg`. This line is commented with a warning. 