### PR TITLE
Register

### DIFF
--- a/tomosaic/util/grid.py
+++ b/tomosaic/util/grid.py
@@ -147,7 +147,10 @@ def find_pairs(file_grid):
 g_shapes = lambda fname: h5py.File(fname, "r")['exchange/data'].shape
 
 
-def refine_shift_grid(grid, shift_grid, motor_readout, savefolder='.', step=200, upsample=100, y_mask=[-5,5], x_mask=[-5,5]):
+def refine_shift_grid(grid, shift_grid, savefolder='.', step=200, upsample=100, y_mask=[-5,5], x_mask=[-5,5], motor_readout=None):
+
+    if motor_readout is None:
+        motor_readout = [shift_grid[1, 0, 0], shift_grid[0, 1, 1]]
 
     if (grid.shape[0] != shift_grid.shape[0] or grid.shape[1] != shift_grid.shape[1]):
         return

--- a/tomosaic/util/grid.py
+++ b/tomosaic/util/grid.py
@@ -147,7 +147,10 @@ def find_pairs(file_grid):
 g_shapes = lambda fname: h5py.File(fname, "r")['exchange/data'].shape
 
 
-def refine_shift_grid(grid, shift_grid, savefolder='.', step=200, upsample=100, y_mask=[-5,5], x_mask=[-5,5], motor_readout=None):
+def refine_shift_grid(grid, shift_grid, src_folder='.', savefolder='.', step=200, upsample=100, y_mask=[-5,5], x_mask=[-5,5], motor_readout=None):
+
+    root = os.getcwd()
+    os.chdir(src_folder)
 
     if motor_readout is None:
         motor_readout = [shift_grid[1, 0, 0], shift_grid[0, 1, 1]]
@@ -252,6 +255,7 @@ def refine_shift_grid(grid, shift_grid, savefolder='.', step=200, upsample=100, 
         for src in range(1, size):
             temp = comm.recv(source=src)
             pairs_shift = pairs_shift + temp
+    os.chdir(root)
     try:
         np.savetxt(savefolder+'/shifts.txt', pairs_shift)
     except:

--- a/tomosaic/util/grid.py
+++ b/tomosaic/util/grid.py
@@ -221,9 +221,9 @@ def refine_shift_grid(grid, shift_grid, src_folder='.', savefolder='.', step=200
                     rangeY = shift_ini[0] + y_mask
                     right_vec = create_stitch_shift(main_prj, right_prj, rangeX, rangeY, down=0, upsample=upsample)
                     # if the computed shift drifts out of the mask, use motor readout instead
-                    if right_vec[0] < y_mask[0] or right_vec[0] > y_mask[1]:
+                    if right_vec[0] <= rangeY[0] or right_vec[0] >= rangeY[1]:
                         right_vec[0] = motor_readout[0]
-                    if right_vec[1] < x_mask[1] or right_vec[1] > x_mask[1]:
+                    if right_vec[1] <= rangeX[0] or right_vec[1] >= rangeX[1]:
                         right_vec[1] = motor_readout[1]
                     pairs_shift[line, 2:4] = right_vec
 
@@ -239,9 +239,9 @@ def refine_shift_grid(grid, shift_grid, src_folder='.', savefolder='.', step=200
                     rangeX = shift_ini[1] + x_mask
                     rangeY = shift_ini[0] + y_mask
                     right_vec = create_stitch_shift(main_prj, bottom_prj, rangeX, rangeY, down=1, upsample=upsample)
-                    if right_vec[0] < y_mask[0] or right_vec[0] > y_mask[1]:
+                    if right_vec[0] <= rangeY[0] or right_vec[0] >= rangeY[1]:
                         right_vec[0] = motor_readout[0]
-                    if right_vec[1] < x_mask[1] or right_vec[1] > x_mask[1]:
+                    if right_vec[1] <= rangeX[0] or right_vec[1] >= rangeX[1]:
                         right_vec[1] = motor_readout[1]
                     pairs_shift[line, 4:6] = right_vec
 


### PR DESCRIPTION
- `refine_shift_grids` now use the maximum of the block stack for correlation, instead of mean. 
- When the correlation results is at the edge of the mask, use motor readout instead. 
- Removed some hardcodes.